### PR TITLE
Avoid hard wrap in markdown files.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,7 @@ After the title, before diving into your first section, you should have some
 level of expository text that explains what the reader can expect to get out of
 reading the page.
 
-Please make sure to keep any individual line under 80 characters except in
-instance where that would break link with the AsciiDoc (which only happens if
-the linked text and url are more than 76 characters).
+Avoid hard-wrapping lines within paragraphs (using line breaks in the middle of or between sentences to make lines shorter than a certain length). Instead, turn on soft-wrapping in your editor and expect the documentation renderer to let the text flow to the width of the container.
 
 ## How to update the Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,20 @@
 # Pony for X
 
-Hello and welcome to "Pony for X". Pony for X is a series of introductions to
-the [Pony](http://www.ponylang.org) programming language aimed at people who
-already know other languages. Each chapter is aimed at users of a specific
-language. Currently we have chapters on C#, Erlang, JavaScript and Java
-underway. If you are interested in contributing, please see our
-[contributing](CONTRIBUTING.md) documentation.
+Hello and welcome to "Pony for X". Pony for X is a series of introductions to the [Pony](http://www.ponylang.org) programming language aimed at people who already know other languages. Each chapter is aimed at users of a specific language. Currently we have chapters on C#, Erlang, JavaScript and Java underway. If you are interested in contributing, please see our [contributing](CONTRIBUTING.md) documentation.
 
 ## Why Pony?
 
-Pony is an open-source, object-oriented, actor-model, capabilities-secure, high 
-performance programming language. It fully recognizes that the future of 
-software development will have to focus on multicore and distributed programs, 
-and that these programs will have to guarantee safety and correct execution.
+Pony is an open-source, object-oriented, actor-model, capabilities-secure, high performance programming language. It fully recognizes that the future of software development will have to focus on multicore and distributed programs, and that these programs will have to guarantee safety and correct execution.
 
-Pony's two main focuses are performance and safety, but it has a slew of other 
-nice features as well.
+Pony's two main focuses are performance and safety, but it has a slew of other nice features as well.
 
 ### Performance
 
-Pony gives us small and fast programs by compiling to optimized native code, 
-instead of running on a resource demanding virtual machine compiling at runtime 
-with a JIT-compiler. Pony also gives us platform portability by using the 
-powerful LLVM backend to produce native binaries for multiple CPUs and OSs.
+Pony gives us small and fast programs by compiling to optimized native code, instead of running on a resource demanding virtual machine compiling at runtime with a JIT-compiler. Pony also gives us platform portability by using the powerful LLVM backend to produce native binaries for multiple CPUs and OSs.
 
-Pony implements the well-known actor model also used by Erlang and Akka, but 
-with more guarantees and delivering better performance. Actors are the basic 
-building blocks of every Pony program, and if needed, millions of actors 
-(each consuming very little resources) can work together in parallel to get 
-things done.
+Pony implements the well-known actor model also used by Erlang and Akka, but with more guarantees and delivering better performance. Actors are the basic building blocks of every Pony program, and if needed, millions of actors (each consuming very little resources) can work together in parallel to get things done.
 
-With Pony we are able to focus on our algorithms and run them on multicore 
-hardware, and worry less about fiddling with error prone primitives like 
-threads and locks.
+With Pony we are able to focus on our algorithms and run them on multicore hardware, and worry less about fiddling with error prone primitives like threads and locks.
 
  * Examples of languages that generate native binaries
     * C/C++ (gcc, LLVM)
@@ -48,25 +30,18 @@ threads and locks.
 
 ### Safety
 
-Pony gives safety on every front so that no Pony program will ever crash. It 
-does this by:
+Pony gives safety on every front so that no Pony program will ever crash. It does this by:
 
  * applying strong type guarantees.
  * implementing concurrent, per-actor garbage collection.
  * not allowing any null or uninitialized values.
  * not allowing shared mutable state.
  * not allowing uncaught exceptions.
- * extending the type system with additional qualifiers (called reference 
- capabilities) making it safe to work on data with multiple actors, while 
- avoiding data-races and deadlocks.
+ * extending the type system with additional qualifiers (called reference capabilities) making it safe to work on data with multiple actors, while avoiding data-races and deadlocks.
 
 ### Other Nice Features
 
- * Pony is simple and approachable, with a clean and concise syntax that is a 
- bit like a sweet mix of Python, Ruby and Scala.
- * Pony is Object Oriented with classes, interfaces and traits, plus it has 
- some functional elements that are a bit like Scala or Erlang.
- * Pony is strongly and statically typed, plus its type system is more powerful 
- and less constricting than most statically typed languages, and has handy 
- features like algebraic types.
+ * Pony is simple and approachable, with a clean and concise syntax that is a bit like a sweet mix of Python, Ruby and Scala.
+ * Pony is Object Oriented with classes, interfaces and traits, plus it has some functional elements that are a bit like Scala or Erlang.
+ * Pony is strongly and statically typed, plus its type system is more powerful and less constricting than most statically typed languages, and has handy features like algebraic types.
  * Pony’s ponyc compiler is fast, which makes it a joy to use.


### PR DESCRIPTION
This PR reformats markdown files to avoid hard wraps in favor of soft wrapping by our text editors and doc renderers.  It also makes this policy clear in `CONTRIBUTING.md`.

See some discussion here: https://github.com/ponylang/pony-for-x/pull/1#issuecomment-217628633
