### PR TITLE
Add guide for comparing Pony to language X section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,4 +63,37 @@ multiple commits, we'll ask you to squash them into a single commit before we
 merge. Steve Klabnik wrote a handy guide for that: 
 [How to squash commits in a GitHub pull request](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request).
 
+## How to compare Pony to language X
 
+The goal of this book is to provide a bridge between langage X and Pony for programmers who are familiar with language X and would like to learn more about Pony. When writing these chapters it one should about why one might use language X, why one might use Pony, and then look for overlapping and divergent concepts.
+
+In order to do that, it is useful to think about particular features of language X, as well as idioms within the language X community, that are interesting and then describe how Pony allows programmers to do something similar. Pony has a `match` statement that is similar to the `match` statement in other languages such as Erlang, but also similar to a `switch` statement in other languages such as Java and C. A discussion of `match` can provide a bridge between Pony and language X by introducing the concept of `match` and how it aligns or does not align with a similar construct in language X. Here is a list of concepts in Pony that may have useful parallels in other languages:
+* lambdas
+* matches
+* for loops
+* tuples and tuple destructuring
+* case functions
+* guard statements on case functions and `match` statements
+* standard library data structures (strings, maps, lists, sets, etc)
+* actors
+* anonymous classes and actors
+* reference capabilities
+* algebraic types
+
+It is also useful to think about features that exist in Pony that may not exist in langage X and describe to a language X developer the benefits of these features using the features of language X that they already understand. For example, many languages provide for concurrent execution via threads and expect the programmer to coordinate data access using things like synchronized blocks and mutexes, while Pony uses actors and reference capabilities to ensure that there are never data races. The list above provides a good starting point for thinking about these things, but here are a few items that are central to Pony and rarely found in other languages:
+* reference capabilities
+* actors and message passing
+* lack of global variables and constants
+* using `primitive`s to represent constants and enums
+
+Finally, language X may have a feature with the same name as a feature in Pony, but they may not behave in exactly the same way. Specifically, these features behave in a way in Pony that might surprise people familiar with them in other languages:
+* lambda
+* class
+* interface
+* trait
+* actor
+The terms "function", "method", and "behavior" also have specific meanings in Pony that may confuse people who have used other languages, so it might be worth discussing them.
+
+When writing examples, try to focus on the interesting features of both languages. For example, most languages have "if ... then ... else" statements, so unless there's a particularly compelling reason to discuss them there's probably no reason to dwell on them. On the other hand, if language X has a system for writing generic classes then it might be worthwhile to compare this to Pony's method.
+
+Each chapter in the book should give a language X developer the confidence to begin reading and writing Pony code based on their existing knowledge of language X.


### PR DESCRIPTION
This guide gives advice for how to write a chapter for the book, with
examples of features of Pony to compare and contrast with other
languages.

The goal is to encourage writers to compare interesting features of
the two languages that do or do not overlap, rather than focusing on
surface things like the syntax of conditional statements or showing
non-idomatic examples.
